### PR TITLE
Villager Trade Duplication Fix

### DIFF
--- a/src/main/java/com/slomaxonical/architectspalette/core/registry/APTrades.java
+++ b/src/main/java/com/slomaxonical/architectspalette/core/registry/APTrades.java
@@ -1,44 +1,53 @@
 package com.slomaxonical.architectspalette.core.registry;
 
 
-import com.slomaxonical.architectspalette.common.factories.BasicTradeFactory;
-import net.fabricmc.fabric.api.object.builder.v1.trade.TradeOfferHelper;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
-import net.minecraft.village.TradeOffer;
+import net.minecraft.village.TradeOffers;
 import net.minecraft.village.VillagerProfession;
+
 import static net.minecraft.village.VillagerProfession.*;
+import static net.minecraft.village.TradeOffers.PROFESSION_TO_LEVELED_TRADE;
 
 
 public class APTrades {
-//    public static void createBasicTrade(VillagerProfession profession, int rank, int priceInEmeralds, ItemStack sellItem,int uses, int exp, Float multiplier){
-//        TradeOfferHelper.registerVillagerOffers(profession,rank,  factories -> factories.add(new BasicTradeFactory(
-//        new TradeOffer(new ItemStack(Items.EMERALD, priceInEmeralds),sellItem,uses,exp,multiplier))));
-//    }
     public static void registerVillagerTrades(){
-//        // Fish Blocks
-//        createBasicTrade(FISHERMAN, 2,2, new ItemStack(APBlocks.COD_LOG, 8), 6, 4, 0.05F);
-//        createBasicTrade(FISHERMAN, 2,2, new ItemStack(APBlocks.SALMON_LOG, 8), 6, 4, 0.05F);
-//        // Entrails
-//        createBasicTrade(BUTCHER, 2, 1, new ItemStack(APBlocks.ENTRAILS, 5), 5, 4, 0.0F);
-//        // Plating
-//        createBasicTrade(ARMORER, 2, 3, new ItemStack(APBlocks.PLATING_BLOCK.BLOCK, 12), 6, 4, 0.1F);
-//        // Pipes
-//        createBasicTrade(TOOLSMITH, 2, 4, new ItemStack(APBlocks.PIPE, 12), 6, 4, 0.1F);
-//        // Spools
-//        createBasicTrade(SHEPHERD, 2, 1, new ItemStack(APBlocks.SPOOL, 2), 5, 4, 0.0F);
-//        // Temporary survival recipes until properly implemented
-//        createBasicTrade(MASON, 1, 1, new ItemStack(APBlocks.LIMESTONE.BLOCK, 16), 5, 3, 0.05F);
-//        createBasicTrade(MASON, 1, 1, new ItemStack(APBlocks.OLIVESTONE_BRICK.BLOCK, 16), 5, 3, 0.05F);
-        TradeOfferHelper.registerVillagerOffers(MASON,1,factories -> factories.add(new BasicTradeFactory(new TradeOffer(new ItemStack(Items.EMERALD, 1),
-                new ItemStack(APBlocks.LIMESTONE.BLOCK,16),5,3,0.05F))));
-        TradeOfferHelper.registerVillagerOffers(MASON,1,factories -> factories.add(new BasicTradeFactory(new TradeOffer(new ItemStack(Items.EMERALD, 1),
-                new ItemStack(APBlocks.OLIVESTONE_BRICK.BLOCK,16),5,3,0.05F))));
-    }
-    public static void registerWanderingTrades(){
-//        TradeOfferHelper.registerWanderingTraderOffers(6,factories -> factories.add(new BasicTradeFactory(new TradeOffer(new ItemStack(Items.EMERALD, 2),new ItemStack(APBlocks.SUNSTONE, 6),20,2,0.0F))));
-//        TradeOfferHelper.registerWanderingTraderOffers(4,factories -> factories.add(new BasicTradeFactory(new TradeOffer(new ItemStack(Items.EMERALD, 2),new ItemStack(APBlocks.MOONSTONE, 6),20,2,0.0F))));
+
+        // Fish Blocks
+        addTrade(FISHERMAN, 2, new TradeOffers.SellItemFactory(new ItemStack(APBlocks.COD_LOG), 2, 8, 6, 4, 0.05F));
+        addTrade(FISHERMAN, 2, new TradeOffers.SellItemFactory(new ItemStack(APBlocks.SALMON_LOG), 2, 8, 6, 4, 0.05F));
+
+        // Entrails
+        addTrade(BUTCHER, 2, new TradeOffers.SellItemFactory(new ItemStack(APBlocks.ENTRAILS), 1, 5, 5, 4, 0.0F));
+
+        // Plating
+        addTrade(ARMORER, 2, new TradeOffers.SellItemFactory(new ItemStack(APBlocks.PLATING_BLOCK.BLOCK), 3, 12, 6, 4, 0.1F));
+
+        // Pipes
+        addTrade(TOOLSMITH, 2, new TradeOffers.SellItemFactory(new ItemStack(APBlocks.PIPE), 4, 12, 6, 4, 0.1F));
+
+        // Spools
+        addTrade(SHEPHERD, 2, new TradeOffers.SellItemFactory(new ItemStack(APBlocks.SPOOL), 1, 2, 5, 4, 0.0F));
+
+
+        // Temporary survival recipes until properly implemented
+        addTrade(MASON, 1, new TradeOffers.SellItemFactory(new ItemStack(APBlocks.LIMESTONE.BLOCK), 1, 16, 5, 3, 0.05F));
+        addTrade(MASON, 1, new TradeOffers.SellItemFactory(new ItemStack(APBlocks.OLIVESTONE_BRICK.BLOCK), 1, 16, 5, 3, 0.05F));
 
     }
 
+    //public static void registerWanderingTrades(){
+    //        TradeOfferHelper.registerWanderingTraderOffers(6,factories -> factories.add(new BasicTradeFactory(new TradeOffer(new ItemStack(Items.EMERALD, 2),new ItemStack(APBlocks.SUNSTONE, 6),20,2,0.0F))));
+    //        TradeOfferHelper.registerWanderingTraderOffers(4,factories -> factories.add(new BasicTradeFactory(new TradeOffer(new ItemStack(Items.EMERALD, 2),new ItemStack(APBlocks.MOONSTONE, 6),20,2,0.0F))));
+    //}
+
+    public static void addTrade (VillagerProfession profession, int level, TradeOffers.Factory trade){
+        TradeOffers.Factory[] fixedTrades = PROFESSION_TO_LEVELED_TRADE.get(profession).get(level);
+        int newSize = fixedTrades.length + 1;
+
+        TradeOffers.Factory[] newTrades = new TradeOffers.Factory[newSize];
+        System.arraycopy(fixedTrades, 0, newTrades, 0, fixedTrades.length);
+        newTrades[newSize - 1] = trade;
+
+        PROFESSION_TO_LEVELED_TRADE.get(profession).put(level, newTrades);
+    }
 }

--- a/src/main/java/com/slomaxonical/architectspalette/core/registry/APTrades.java
+++ b/src/main/java/com/slomaxonical/architectspalette/core/registry/APTrades.java
@@ -6,39 +6,59 @@ import net.fabricmc.fabric.api.object.builder.v1.trade.TradeOfferHelper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.village.TradeOffer;
+import net.minecraft.village.TradeOffers;
 import net.minecraft.village.VillagerProfession;
+
 import static net.minecraft.village.VillagerProfession.*;
+import static net.minecraft.village.TradeOffers.PROFESSION_TO_LEVELED_TRADE;
 
 
 public class APTrades {
-//    public static void createBasicTrade(VillagerProfession profession, int rank, int priceInEmeralds, ItemStack sellItem,int uses, int exp, Float multiplier){
-//        TradeOfferHelper.registerVillagerOffers(profession,rank,  factories -> factories.add(new BasicTradeFactory(
-//        new TradeOffer(new ItemStack(Items.EMERALD, priceInEmeralds),sellItem,uses,exp,multiplier))));
-//    }
-    public static void registerVillagerTrades(){
-//        // Fish Blocks
-//        createBasicTrade(FISHERMAN, 2,2, new ItemStack(APBlocks.COD_LOG, 8), 6, 4, 0.05F);
-//        createBasicTrade(FISHERMAN, 2,2, new ItemStack(APBlocks.SALMON_LOG, 8), 6, 4, 0.05F);
-//        // Entrails
-//        createBasicTrade(BUTCHER, 2, 1, new ItemStack(APBlocks.ENTRAILS, 5), 5, 4, 0.0F);
-//        // Plating
-//        createBasicTrade(ARMORER, 2, 3, new ItemStack(APBlocks.PLATING_BLOCK.BLOCK, 12), 6, 4, 0.1F);
-//        // Pipes
-//        createBasicTrade(TOOLSMITH, 2, 4, new ItemStack(APBlocks.PIPE, 12), 6, 4, 0.1F);
-//        // Spools
-//        createBasicTrade(SHEPHERD, 2, 1, new ItemStack(APBlocks.SPOOL, 2), 5, 4, 0.0F);
-//        // Temporary survival recipes until properly implemented
-//        createBasicTrade(MASON, 1, 1, new ItemStack(APBlocks.LIMESTONE.BLOCK, 16), 5, 3, 0.05F);
-//        createBasicTrade(MASON, 1, 1, new ItemStack(APBlocks.OLIVESTONE_BRICK.BLOCK, 16), 5, 3, 0.05F);
-        TradeOfferHelper.registerVillagerOffers(MASON,1,factories -> factories.add(new BasicTradeFactory(new TradeOffer(new ItemStack(Items.EMERALD, 1),
-                new ItemStack(APBlocks.LIMESTONE.BLOCK,16),5,3,0.05F))));
-        TradeOfferHelper.registerVillagerOffers(MASON,1,factories -> factories.add(new BasicTradeFactory(new TradeOffer(new ItemStack(Items.EMERALD, 1),
-                new ItemStack(APBlocks.OLIVESTONE_BRICK.BLOCK,16),5,3,0.05F))));
+    public static void createBasicTrade(VillagerProfession profession, int rank, int priceInEmeralds, ItemStack sellItem,int uses, int exp, Float multiplier){
+        TradeOfferHelper.registerVillagerOffers(profession,rank,  factories -> factories.add(new BasicTradeFactory(
+        new TradeOffer(new ItemStack(Items.EMERALD, priceInEmeralds),sellItem,uses,exp,multiplier))));
     }
-    public static void registerWanderingTrades(){
-//        TradeOfferHelper.registerWanderingTraderOffers(6,factories -> factories.add(new BasicTradeFactory(new TradeOffer(new ItemStack(Items.EMERALD, 2),new ItemStack(APBlocks.SUNSTONE, 6),20,2,0.0F))));
-//        TradeOfferHelper.registerWanderingTraderOffers(4,factories -> factories.add(new BasicTradeFactory(new TradeOffer(new ItemStack(Items.EMERALD, 2),new ItemStack(APBlocks.MOONSTONE, 6),20,2,0.0F))));
+    public static void registerVillagerTrades(){
+
+        // Fish Blocks
+        addTrade(FISHERMAN, 2, new TradeOffers.SellItemFactory(new ItemStack(APBlocks.COD_LOG), 2, 8, 6, 4, 0.05F));
+        addTrade(FISHERMAN, 2, new TradeOffers.SellItemFactory(new ItemStack(APBlocks.SALMON_LOG), 2, 8, 6, 4, 0.05F));
+
+        // Entrails
+        addTrade(BUTCHER, 2, new TradeOffers.SellItemFactory(new ItemStack(APBlocks.ENTRAILS), 1, 5, 5, 4, 0.0F));
+
+        // Plating
+        addTrade(ARMORER, 2, new TradeOffers.SellItemFactory(new ItemStack(APBlocks.PLATING_BLOCK.BLOCK), 3, 12, 6, 4, 0.1F));
+
+        // Pipes
+        addTrade(TOOLSMITH, 2, new TradeOffers.SellItemFactory(new ItemStack(APBlocks.PIPE), 4, 12, 6, 4, 0.1F));
+
+        // Spools
+        addTrade(SHEPHERD, 2, new TradeOffers.SellItemFactory(new ItemStack(APBlocks.SPOOL), 1, 2, 5, 4, 0.0F));
+
+
+        // Temporary survival recipes until properly implemented
+        addTrade(MASON, 1, new TradeOffers.SellItemFactory(new ItemStack(APBlocks.LIMESTONE.BLOCK), 1, 16, 5, 3, 0.05F));
+        addTrade(MASON, 1, new TradeOffers.SellItemFactory(new ItemStack(APBlocks.OLIVESTONE_BRICK.BLOCK), 1, 16, 5, 3, 0.05F));
 
     }
+
+    //public static void registerWanderingTrades(){
+    //        TradeOfferHelper.registerWanderingTraderOffers(6,factories -> factories.add(new BasicTradeFactory(new TradeOffer(new ItemStack(Items.EMERALD, 2),new ItemStack(APBlocks.SUNSTONE, 6),20,2,0.0F))));
+    //        TradeOfferHelper.registerWanderingTraderOffers(4,factories -> factories.add(new BasicTradeFactory(new TradeOffer(new ItemStack(Items.EMERALD, 2),new ItemStack(APBlocks.MOONSTONE, 6),20,2,0.0F))));
+    //}
+
+    public static void addTrade (VillagerProfession profession, int level, TradeOffers.Factory trade){
+        TradeOffers.Factory[] fixedTrades = PROFESSION_TO_LEVELED_TRADE.get(profession).get(level);
+        int newSize = fixedTrades.length + 1;
+
+        TradeOffers.Factory[] newTrades = new TradeOffers.Factory[newSize];
+        System.arraycopy(fixedTrades, 0, newTrades, 0, fixedTrades.length);
+        newTrades[newSize - 1] = trade;
+
+        PROFESSION_TO_LEVELED_TRADE.get(profession).put(level, newTrades);
+    }
+
+
 
 }

--- a/src/main/resources/architects_palette.accesswidener
+++ b/src/main/resources/architects_palette.accesswidener
@@ -1,4 +1,4 @@
 accessWidener v1 named
-
+accessible class net/minecraft/village/TradeOffers$SellItemFactory
 accessible field net/minecraft/item/AxeItem STRIPPED_BLOCKS Ljava/util/Map;
 mutable field net/minecraft/item/AxeItem STRIPPED_BLOCKS Ljava/util/Map;


### PR DESCRIPTION
So I was able to, thanks to a number of code examples, but finally, the code example of Telepathic Grunt, able to find out how to use the vanilla `SellItemFactory`. Also DrexHD was the one who explained to me how accesswideners work, so I wasn't completely lost when I looked at your code and saw what you had done already.

It is possible that there has already been a correction with FAPI, but if the issue still persists, I wanted to send this over to you.

I was unable to figure out how to get the Wandering Trader trades to work after mucking about with them for a few hours; so I apologise for that. I hope this was useful! If it was already fixed, it was still a great learning experience for me. 😃

I left the `BasicTradeFactory` intact for whenever FAPI gets fixed if you want to reuse it if you end up using this PR.